### PR TITLE
Create an output directory if it does not exist already

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,10 @@ def main():
     full_repo_name = args.full_repo_name       # now comes from CLI
     issue_number = args.issue_number  # now comes from CLI
 
+    # create an 'outputs' directory to store full info
+    output_dir = os.path.join(os.getcwd(), "outputs")
+    os.makedirs(output_dir, exist_ok=True)
+
     try:
         # owner, repo = parse_github_url(repo_url)
         repo_url, owner, repo = parse_full_repo_name(full_repo_name)


### PR DESCRIPTION
Currently, the tool fails as it expects an output directory to be made by the user already. The PR fixes this issue by ensuring an output folder exists before proceeding. If not present, it creates one.